### PR TITLE
Use alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM circleci/ruby:2.2.7
 WORKDIR /root/
 ADD work work
 
-COPY work/Gemfile $WORKDIR
-
 RUN sudo apt-get update && sudo apt-get upgrade -y
 RUN sudo apt-get install -y libpcap-dev
+
+COPY work/Gemfile $WORKDIR
+COPY work/Gemfile.lock $WORKDIR
 
 WORKDIR /root/work/
 RUN sudo gem update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM circleci/ruby:2.2.7
-WORKDIR /root/
-ADD work work
+FROM ruby:2.5.0-alpine
 
-RUN sudo apt-get update && sudo apt-get upgrade -y
-RUN sudo apt-get install -y libpcap-dev
+RUN apk --update --no-cache --virtual add libpcap-dev make gcc g++
+
+WORKDIR /root/work
 
 COPY work/Gemfile $WORKDIR
 COPY work/Gemfile.lock $WORKDIR
 
-WORKDIR /root/work/
-RUN sudo gem update
-RUN sudo bundle install
+RUN bundle install


### PR DESCRIPTION
`gunosy/circleci_codenize_tools` image is very large because base image is `circleci/ruby:2.2.7`.

By using alpine image, `gunosy/circleci_codenize_tools` image size decreases about 1G.

```
% docker images
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
codenize                         latest              f682db307cce        11 minutes ago      288MB
gunosy/circleci_codenize_tools   latest              9bf41b4b7891        5 weeks ago         1.36GB
```
