### PR TITLE
update ruby version to 2.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.2.7
+FROM circleci/ruby:2.3.7
 WORKDIR /root/
 ADD work work
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/

